### PR TITLE
fix: make credentials optional

### DIFF
--- a/src/services/collaborativesearch.service.ts
+++ b/src/services/collaborativesearch.service.ts
@@ -28,7 +28,7 @@ import { CollectionCount, fromEntries } from '../utils/utils';
 import { ConfigService } from './config.service';
 
 export interface FetchOptions {
-    credentials: string;
+    credentials?: string;
     signal?: AbortSignal;
     responseType?: string;
     referrerPolicy?: string;


### PR DESCRIPTION
This change is made as there was a misinterpretation when I applied the strict typing: credentials were listed as required, but just because they were given by default.